### PR TITLE
Add equivocation report logging functionality

### DIFF
--- a/monitor/blocks.py
+++ b/monitor/blocks.py
@@ -46,7 +46,14 @@ def get_proposer(canonicalized_block):
 
 def bare_hash(canonicalized_block):
     """Return the hash of a block excluding its seal fields."""
+    encoded_block = rlp_encoded_block(canonicalized_block)
+    return keccak(encoded_block)
+
+
+def rlp_encoded_block(canonicalized_block):
+    """Return the RLP encoded block header excluding its seal fields."""
     assert len(canonicalized_block.sealFields) >= 2
+
     if len(canonicalized_block.sealFields) > 2:
         raise ValueError(
             "Bare hash for blocks with empty step transitions is not supported"
@@ -67,7 +74,8 @@ def bare_hash(canonicalized_block):
         canonicalized_block.timestamp,
         canonicalized_block.extraData,
     ]
-    return keccak(rlp.encode(serialized))
+
+    return rlp.encode(serialized)
 
 
 def calculate_block_signature(canonicalized_block, private_key):

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -252,15 +252,15 @@ class App:
     def equivocation_logger(self, equivocated_block_hashes):
         """Log a reported equivocation event.
 
-        Each new equivocation report is logged into a new file, using a counter
-        as unique identifier.
-        Logged information are the proposer of the blocks, the height at which
-        all blocks have been equivocated and a list of all block hashes with
-        their timestamp.
-        Additionally two representing blocks are logged with their RLP encoded
-        header and related signature, which can be used for an equivocation
-        proof on reporting a validator.
+        Equivocation reports are logged into files separated by the proposers
+        address. Logged information are the proposer of the blocks, the height
+        at which all blocks have been equivocated and a list of all block hashes
+        with their timestamp. Additionally two representing blocks are logged
+        with their RLP encoded header and related signature, which can be used
+        for an equivocation proof on reporting a validator.
         """
+
+        assert len(equivocated_block_hashes) >= 2
 
         blocks = [
             self.w3.eth.getBlock(block_hash) for block_hash in equivocated_block_hashes


### PR DESCRIPTION
**Closes:**
 - #3

**Related to:**
 - trustlines-network/project#299
 - trustlines-network/project#299

The logging has been tested by a local chain setup of two nodes, including one validator. The chain specification includes 5 validators, while 4 are offline, so no block reaches finality. The monitoring service connects to the non-validating node.
Both nodes are started, where the monitoring service is fetching the blocks from the non-validating node. At block `N` all nodes get stopped. The validators database gets deleted and the node restarted, sealing new blocks from genesis. As soon as the validator reaches `N+1` blocks, the non-validators connects again. The non-validator has to reorganize his chain, so the new blocks get fetched by the monitoring service as well. Equivocation reporter detects blocks by the same proposer for the same height (`N` times).

This is how such report looks like:
```
Proposer: 0xf59ca8dfed7f0c31feb86111a62a28260a1f1470
Block height: 1
Detection time: 2019-02-28 16:18:04.376685

Equivocated blocks:
0xa98ddece1763252c1e121e9b6fd60fbdb695c4de015a15abfb127596a4f5e0ba (2019-02-28 16:15:50)
0x68950e0a469c2285ada44cf3313ca7d3cbf203938c69db69180f0eaffeead841 (2019-02-28 16:17:05)

Data for an equivocation proof by the first two equivocated blocks:

RLP encoded block header one:
b'\xf9\x01\xf9\xa0\xab%\x90!\xa2\xd2\xc2\x07\x8a\xdaA\x153\xea\xca+\xfaq\x1f\xa6\xfe\xf3\x8ag\xcf\xcd\tc\x13F\xae*\xa0\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G\x94\xf5\x9c\xa8\xdf\xed\x7f\x0c1\xfe\xb8a\x11\xa6*(&\n\x1f\x14p\xa02\xc3\xf6uIA\x14\x95\xcdG\xd1\x82\xdcC4\x89>5\xacF\x08\x08`Z\xb1\x87\x8f\x071\x8d\x10*\xa0V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!\xa0V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!\xb9\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xed\x81\x97\xc1\x01\x83z\x12\x00\x80\x84\\x\t6\x9f\xde\x83\x02\x03\x00\x8fParity-Ethereum\x861.30.0\x82li'

Signature of block header one:
0xc5102a8d8d3a9b03e000a9893df66e2ce933534694c46d3a3244a8931cfe8a2345a35f2c2e45e4aa54e1994a63b73dcca5703de625897b0fab45d2437755e4a100

RLP encoded block header two:
b'\xf9\x01\xf9\xa0\xab%\x90!\xa2\xd2\xc2\x07\x8a\xdaA\x153\xea\xca+\xfaq\x1f\xa6\xfe\xf3\x8ag\xcf\xcd\tc\x13F\xae*\xa0\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G\x94\xf5\x9c\xa8\xdf\xed\x7f\x0c1\xfe\xb8a\x11\xa6*(&\n\x1f\x14p\xa02\xc3\xf6uIA\x14\x95\xcdG\xd1\x82\xdcC4\x89>5\xacF\x08\x08`Z\xb1\x87\x8f\x071\x8d\x10*\xa0V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!\xa0V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!\xb9\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xed\x81\x97\xb2\x01\x83z\x12\x00\x80\x84\\x\t\x81\x9f\xde\x83\x02\x03\x00\x8fParity-Ethereum\x861.30.0\x82li'

Signature of block header two:
0xd906d6eb396903c02e2c972ffbb567a6a1461d6b866288bad9c03e247e86cf925806d8d224e825d674f32529fba13f22f4100a3a290d45066b2343430766766600
```