### PR TITLE
Feature/synchronize from non genesis block 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Options:
   -c, --chain-spec-path FILE      path to the chain spec file of the
                                   Trustlines blockchain  [required]
   -r, --report-dir DIRECTORY      path to the directory in which misbehavior
-                                  reports will be created  [default:
-                                  /home/ralf/trustlines/tlbc-monitor/reports]
+                                  reports will be created  [default: reports]
   -d, --db-dir DIRECTORY          path to the directory in which the database
                                   and application state will be stored
                                   [default: state]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ docker build -t tlbc-monitor .
 
 `tlbc-monitor` provides the following CLI interface:
 
-```
-Usage: tlbc-monitor [OPTIONS]
+```Usage: tlbc-monitor [OPTIONS]
 
 Options:
   -u, --rpc-uri TEXT              URI of the node's JSON RPC server  [default:
@@ -33,10 +32,10 @@ Options:
                                   Trustlines blockchain  [required]
   -r, --report-dir DIRECTORY      path to the directory in which misbehavior
                                   reports will be created  [default:
-                                  <...>/tlbc-monitor/reports]
+                                  /home/ralf/trustlines/tlbc-monitor/reports]
   -d, --db-dir DIRECTORY          path to the directory in which the database
                                   and application state will be stored
-                                  [default: <...>/tlbc- monitor/state]
+                                  [default: state]
   -o, --skip-rate FLOAT           maximum rate of assigned steps a validator
                                   can skip without being reported as offline
                                   [default: 0.5]
@@ -44,8 +43,20 @@ Options:
                                   size in seconds of the time window
                                   considered when determining if validators
                                   are offline or not  [default: 86400]
-  --help                          Show this message and exit
+  --sync-from TEXT                starting block  [default: -35000]
+  --help                          Show this message and exit.
 ```
+
+The --sync-from argument is used to select a starting block, where the
+synchronization starts. It can be given in multiple ways:
+- a non-negative integer specifies a blocknumber
+- a negative integer N selects the block -N blocks before the latest block
+- a date in the format 'YYYY-MM-DD' selects the first block validated after that date.
+- `genesis` selects the block with number 0
+- `latest` selects the latest block`
+
+Please note that the actual block being used will differ, if the selected block
+is less than 1000 blocks away from the latest block.
 
 In production, the monitor will usually run inside a Docker container and interact with another container housing a Parity client connected to the Trustlines blockchain. Here's a command typical for such a setting:
 

--- a/monitor/blocksel.py
+++ b/monitor/blocksel.py
@@ -49,7 +49,7 @@ class ResolveLatestBlock(ResolveBlock):
 
     @classmethod
     def from_blockselector(cls, blocksel):
-        if blocksel not in ("latest", "-0"):
+        if blocksel != "latest":
             raise ValueError()
         return cls()
 

--- a/monitor/blocksel.py
+++ b/monitor/blocksel.py
@@ -1,0 +1,105 @@
+"""allow selection of an initial block"""
+import abc
+import datetime
+
+
+class ResolveBlock(metaclass=abc.ABCMeta):
+    @classmethod
+    @abc.abstractmethod
+    def from_blockselector(cls, blocksel):
+        pass
+
+    @abc.abstractmethod
+    def resolve_block(self, w3):
+        pass
+
+
+class ResolveBlockByNumber(ResolveBlock):
+    """resolve a block by number"""
+
+    @classmethod
+    def from_blockselector(cls, blocksel):
+        return cls(int(blocksel))
+
+    def __init__(self, blocksel):
+        self.blocknr = blocksel
+
+    def resolve_block(self, w3):
+        if self.blocknr < 0:
+            blocknr = max(0, w3.eth.blockNumber + self.blocknr)
+        else:
+            blocknr = self.blocknr
+
+        return w3.eth.getBlock(blocknr)
+
+
+class ResolveGenesisBlock(ResolveBlock):
+    @classmethod
+    def from_blockselector(cls, blocksel):
+        if blocksel not in ("genesis", "0"):
+            raise ValueError()
+        return cls()
+
+    def resolve_block(self, w3):
+        return w3.eth.getBlock(0)
+
+
+class ResolveLatestBlock(ResolveBlock):
+    """resolves to the latest block"""
+
+    @classmethod
+    def from_blockselector(cls, blocksel):
+        if blocksel not in ("latest", "-0"):
+            raise ValueError()
+        return cls()
+
+    def resolve_block(self, w3):
+        return w3.eth.getBlock("latest")
+
+
+def parse_date(s):
+    """parse date from given string in format YYYY-MM-DD returns an aware UTC
+    datetime object for the start of that day"""
+    return datetime.datetime.strptime(s, "%Y-%m-%d").replace(
+        tzinfo=datetime.timezone.utc
+    )
+
+
+class ResolveBlockByDate(ResolveBlock):
+    """resolves to the first block after a given date
+
+    This does a binary search to find that block
+    """
+
+    @classmethod
+    def from_blockselector(cls, blocksel):
+        return cls(parse_date(blocksel).timestamp())
+
+    def __init__(self, timestamp):
+        self.timestamp = timestamp
+
+    def resolve_block(self, w3):
+        lower_block = w3.eth.getBlock(0)
+        upper_block = w3.eth.getBlock("latest")
+        while upper_block.number - lower_block.number > 1:
+            middle = w3.eth.getBlock((lower_block.number + upper_block.number) // 2)
+            if self.timestamp >= middle.timestamp:
+                lower_block = middle
+            else:
+                upper_block = middle
+        return lower_block
+
+
+def make_blockresolver(blockselector):
+    """given a blockselector string, try to return a blockresolver"""
+    for cls in [
+        ResolveLatestBlock,
+        ResolveGenesisBlock,
+        ResolveBlockByNumber,
+        ResolveBlockByDate,
+    ]:
+        try:
+            return cls.from_blockselector(blockselector)
+        except ValueError:
+            pass
+    raise ValueError("Could not parse blockselector")

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -351,7 +351,7 @@ def validate_skip_rate(ctx, param, value):
     type=click.IntRange(min=0),
     help="size in seconds of the time window considered when determining if validators are offline or not",
 )
-@click.option("--sync-from", default="-35000", show_default=True, help="starting block")
+@click.option("--sync-from", default="-1000", show_default=True, help="starting block")
 def main(
     rpc_uri,
     chain_spec_path,


### PR DESCRIPTION
@jannikluhn you've already seen the first part of this. I've basically only introduced a new way to select a starting block based on a date and added some changes to the logging. I do think it would make sense if we always log the timestamp of a block in addition to it's blocknumber and hash.

implements https://github.com/trustlines-network/tlbc-monitor/issues/10
